### PR TITLE
Fix c type casts for winmm port

### DIFF
--- a/portmidi/pm_win/pmwinmm.c
+++ b/portmidi/pm_win/pmwinmm.c
@@ -35,14 +35,14 @@
 
 /* callback routines */
 static void CALLBACK winmm_in_callback(HMIDIIN hMidiIn,
-                                       WORD wMsg, DWORD dwInstance, 
-                                       DWORD dwParam1, DWORD dwParam2);
+                                       WORD wMsg, DWORD_PTR dwInstance, 
+                                       DWORD_PTR dwParam1, DWORD_PTR dwParam2);
 static void CALLBACK winmm_streamout_callback(HMIDIOUT hmo, UINT wMsg,
-                                              DWORD dwInstance, DWORD dwParam1, 
-                                              DWORD dwParam2);
+                                              DWORD_PTR dwInstance, DWORD_PTR dwParam1, 
+                                              DWORD_PTR dwParam2);
 static void CALLBACK winmm_out_callback(HMIDIOUT hmo, UINT wMsg,
-                                        DWORD dwInstance, DWORD dwParam1, 
-                                        DWORD dwParam2);
+                                        DWORD_PTR dwInstance, DWORD_PTR dwParam1, 
+                                        DWORD_PTR dwParam2);
 
 extern pm_fns_node pm_winmm_in_dictionary;
 extern pm_fns_node pm_winmm_out_dictionary;
@@ -578,8 +578,8 @@ static PmError winmm_in_open(PmInternal *midi, void *driverInfo)
     /* open device */
     pm_hosterror = midiInOpen(&(m->handle.in),  /* input device handle */
                               dwDevice,  /* device ID */
-                              (DWORD) winmm_in_callback,  /* callback address */
-                              (DWORD) midi,  /* callback instance data */
+                              (DWORD_PTR) winmm_in_callback,  /* callback address */
+                              (DWORD_PTR) midi,  /* callback instance data */
                               CALLBACK_FUNCTION); /* callback is a procedure */
     if (pm_hosterror) goto free_descriptor;
 
@@ -661,9 +661,9 @@ static PmError winmm_in_close(PmInternal *midi)
 static void FAR PASCAL winmm_in_callback(
     HMIDIIN hMidiIn,    /* midiInput device Handle */
     WORD wMsg,          /* midi msg */
-    DWORD dwInstance,   /* application data */
-    DWORD dwParam1,     /* MIDI data */
-    DWORD dwParam2)    /* device timestamp (wrt most recent midiInStart) */
+    DWORD_PTR dwInstance,   /* application data */
+    DWORD_PTR dwParam1,     /* MIDI data */
+    DWORD_PTR dwParam2)    /* device timestamp (wrt most recent midiInStart) */
 {
     static int entry = 0;
     PmInternal *midi = (PmInternal *) dwInstance;
@@ -859,16 +859,16 @@ static PmError winmm_out_open(PmInternal *midi, void *driverInfo)
         pm_hosterror = midiOutOpen((LPHMIDIOUT) & m->handle.out,  /* device Handle */
                                    dwDevice,  /* device ID  */
                                    /* note: same callback fn as for StreamOpen: */
-                                   (DWORD) winmm_streamout_callback, /* callback fn */
-                                   (DWORD) midi,  /* callback instance data */
+                                   (DWORD_PTR) winmm_streamout_callback, /* callback fn */
+                                   (DWORD_PTR) midi,  /* callback instance data */
                                    CALLBACK_FUNCTION); /* callback type */
     } else {
         /* use stream-based midi output (schedulable in future) */
         pm_hosterror = midiStreamOpen(&m->handle.stream,  /* device Handle */
                                       (LPUINT) & dwDevice,  /* device ID pointer */
                                       1,  /* reserved, must be 1 */
-                                      (DWORD) winmm_streamout_callback,
-                                      (DWORD) midi,  /* callback instance data */
+                                      (DWORD_PTR) winmm_streamout_callback,
+                                      (DWORD_PTR) midi,  /* callback instance data */
                                       CALLBACK_FUNCTION);
     }
     if (pm_hosterror != MMSYSERR_NOERROR) {
@@ -1288,8 +1288,8 @@ static PmTimestamp winmm_synchronize(PmInternal *midi)
 #ifdef USE_SYSEX_BUFFERS
 /* winmm_out_callback -- recycle sysex buffers */
 static void CALLBACK winmm_out_callback(HMIDIOUT hmo, UINT wMsg,
-                                        DWORD dwInstance, DWORD dwParam1, 
-                                        DWORD dwParam2)
+                                        DWORD_PTR dwInstance, DWORD_PTR dwParam1, 
+                                        DWORD_PTR dwParam2)
 {
     PmInternal *midi = (PmInternal *) dwInstance;
     midiwinmm_type m = (midiwinmm_type) midi->descriptor;
@@ -1314,7 +1314,7 @@ static void CALLBACK winmm_out_callback(HMIDIOUT hmo, UINT wMsg,
 
 /* winmm_streamout_callback -- unprepare (free) buffer header */
 static void CALLBACK winmm_streamout_callback(HMIDIOUT hmo, UINT wMsg,
-        DWORD dwInstance, DWORD dwParam1, DWORD dwParam2)
+        DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2)
 {
     PmInternal *midi = (PmInternal *) dwInstance;
     midiwinmm_type m = (midiwinmm_type) midi->descriptor;

--- a/portmidi/porttime/ptwinmm.c
+++ b/portmidi/porttime/ptwinmm.c
@@ -14,8 +14,8 @@ static long time_resolution;
 static MMRESULT timer_id;
 static PtCallback *time_callback;
 
-void CALLBACK winmm_time_callback(UINT uID, UINT uMsg, DWORD dwUser, 
-                                  DWORD dw1, DWORD dw2)
+void CALLBACK winmm_time_callback(UINT uID, UINT uMsg, DWORD_PTR dwUser, 
+                                  DWORD_PTR dw1, DWORD_PTR dw2)
 {
     (*time_callback)(Pt_Time(), (void *) dwUser);
 }
@@ -31,7 +31,7 @@ PtError Pt_Start(int resolution, PtCallback *callback, void *userData)
     time_callback = callback;
     if (callback) {
         timer_id = timeSetEvent(resolution, 1, winmm_time_callback, 
-            (DWORD) userData, TIME_PERIODIC | TIME_CALLBACK_FUNCTION);
+            (DWORD_PTR) userData, TIME_PERIODIC | TIME_CALLBACK_FUNCTION);
         if (!timer_id) return ptHostError;
     }
     return ptNoError;


### PR DESCRIPTION
Besides the wrong callback pointer casts, 
the parameters of callbacks to midi open functions should have type DWORD_PTR which will be 64bit long under x86_64 according to [[1]](https://msdn.microsoft.com/en-us/library/windows/desktop/dd798460%28v=vs.85%29.aspx) and [[2]](https://msdn.microsoft.com/en-us/library/windows/desktop/dd798478%28v=vs.85%29.aspx)
