### PR TITLE
Revisited error reporting, fixed pedantic warnings, added poll binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+This project adheres to [Haskell PVP](https://pvp.haskell.org/).
+
+
+## 0.2.0.0 [not released]
+
+- [Breaking change] :
+  The non-error constructor 'NoError' and 'GotData' were moved from 'PMError'
+  to a new type 'PMSuccess', so that 'PMError' only contains real errors.
+  To adhere to the 'Either' conventions where errors are returned in 'Left',
+  successes in 'Right',
+  functions that returned 'PmError' now return 'Either PmError PMSuccess' and
+  functions that returned 'Either <Type-for-success> PmError' now return
+  'Either PmError <Type-for-success>'.
+
+## 0.1.6.1 (last version on hackage when the Changelog was created)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,12 @@ The format of this changelog is based on
 
 ## 0.2.0.0 [not released]
 ### Changed
-- Error reporting (Breaking change)
-  * All functions now adhere to the 'Either' conventions:
-    * Real errors are returned in a 'Left',
-    * Successes are returned in a 'Right'.
-  * To achieve this, the non-errors constructors of 'PMError',
-      namely 'NoError' and 'GotData', were moved to a new type 'PMSuccess'.
-  This change will likely simplify error management at call site,
-  with a minor refactoring.
+- Error reporting (Breaking change).
+  All functions now adhere to the 'Either' conventions:
+    real errors are returned in a 'Left',
+    successes are returned in a 'Right'.
+  To achieve this, the non-errors constructors of 'PMError',
+    namely 'NoError' and 'GotData', were moved to a new type 'PMSuccess'.
 
 ### Added
 - The `poll` function was added (it binds to `Pm_Poll`) : it allows to know,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,181 @@
 
 This project adheres to [Haskell PVP](https://pvp.haskell.org/).
 
+The format of this changelog is based on
+[Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
 
 ## 0.2.0.0 [not released]
+### Changed
+- Error reporting (Breaking change)
+  * All functions now adhere to the 'Either' conventions:
+    * Real errors are returned in a 'Left',
+    * Successes are returned in a 'Right'.
+  * To achieve this, the non-errors constructors of 'PMError',
+      namely 'NoError' and 'GotData', were moved to a new type 'PMSuccess'.
+  This change will likely simplify error management at call site,
+  with a minor refactoring.
 
-- [Breaking change] :
-  The non-error constructor 'NoError' and 'GotData' were moved from 'PMError'
-  to a new type 'PMSuccess', so that 'PMError' only contains real errors.
-  To adhere to the 'Either' conventions where errors are returned in 'Left',
-  successes in 'Right',
-  functions that returned 'PmError' now return 'Either PmError PMSuccess' and
-  functions that returned 'Either <Type-for-success> PmError' now return
-  'Either PmError <Type-for-success>'.
+### Added
+- The `poll` function was added (it binds to `Pm_Poll`) : it allows to know,
+  without reading the events, if some events are present.
 
-## 0.1.6.1 (last version on hackage when the Changelog was created)
+
+## 0.1.6.1
+
+commit 3b92597d84113969371612fb5c590b9f8c77d53c
+Author: Paul H. Liu <paul@thev.net>
+Date:   Wed Jul 6 09:34:40 2016 -0700
+
+    Fix case sensitivity, and bump version to 0.1.6.1 to correct version number
+
+commit 2d5266dd325f2c248a9022679abfcebe9b317a95
+Author: Paul H. Liu <paul@thev.net>
+Date:   Tue Jul 5 21:37:24 2016 -0700
+
+    Move to github, and bump version to 0.1.5.3
+
+commit d7946afcfd7c3204c1ea999ed7fdb9c4e9ff20a7
+Author: Paul Liu <paul@thev.net>
+Date:   Sun Apr 3 00:46:02 2016 -0700
+
+    PMEvent uses CLong as message type to better handle SysEx.
+
+    Ignore-this: 367f146403228813c914a23bfc2a1248
+    - This is a breaking change. Use encodeMsg or decodeMsg to work with PMMsg.
+
+    darcs-hash:20160403074602-da8e5-05c03013660b8fc91f843fa22143ec2b7ea5d7b5
+
+commit d5217416a5477f10a36727254425a572d18b7e4a
+Author: Paul Liu <paul@thev.net>
+Date:   Sun Apr 3 00:40:29 2016 -0700
+
+    Use LANGUAGE pragma instead of OPTIONS_GHC
+
+    Ignore-this: c65fb70875497b8e6c46f76ee9105dbe
+
+    darcs-hash:20160403074029-da8e5-378ba491b94131265a94f115bf068971f869ea2b
+
+commit 358452adfcf91c2436752f9b95ebcc5d5124db97
+Author: Paul Liu <paul@thev.net>
+Date:   Sun Apr 3 00:40:09 2016 -0700
+
+    Detect freebsd OS
+
+    Ignore-this: 9f819a332d364679acc2e005488f9375
+
+    darcs-hash:20160403074009-da8e5-16571867d53492c3fb7dc84df8fb8a500a71312a
+
+commit c64496ded49633100864e8e0e192a9333ef8caa5
+Author: Paul Liu <paul@thev.net>
+Date:   Mon Sep 21 22:17:09 2015 -0700
+
+    Add CHANGELOG.txt to package, and bump version to 0.1.5.2
+
+    Ignore-this: 465173236978f9557dbbc574b5d34a8f
+
+    darcs-hash:20150922051709-da8e5-824c6e4c060e3c85ee3831cebde4a88fd3f8582b
+
+commit fda70ecb49f85fd4dccc5daaecbdd9f96fe1651f
+Author: Paul Liu <paul@thev.net>
+Date:   Mon Sep 21 11:29:09 2015 -0700
+
+    Update README and bump version to 0.1.5.1
+
+    Ignore-this: 98500cbf8d27a5068949cb458648500e
+
+    darcs-hash:20150921182909-da8e5-fc100f8c68c20229a726f31ce8fd7051e8c13163
+
+commit 044b0f47f3fc3bc6ade39c2972fb4b40c16c4e05
+Author: Paul Liu <paul@thev.net>
+Date:   Mon Sep 21 11:17:37 2015 -0700
+
+    Bump version to 0.1.5
+
+    Ignore-this: 4fb2ae12ea9145bac0f0459ff3073169
+
+    darcs-hash:20150921181737-da8e5-75d0be5001d877daf0c359687c66408afec0639b
+
+commit a158c93a9d50c8bc56a3be908effd4020f9e7cc0
+Author: Mark Lentczner <mark.lentczner@gmail.com>
+Date:   Mon Sep 21 11:16:04 2015 -0700
+
+    On some systems, Int is not the same size as CInt.
+
+    Ignore-this: 7bd6231264f14d66dd4c0156cc3266ba
+
+    - Added hidden module Sound.PortMidi.DeviceInfo, moving DeviceInfo and peekDeviceInfo there
+     - this allowed it to be a hsc2hs module, enabling peekDeviceInfo to use C generated structure offsets and sizes
+    - FFI declarations for C calls that take and return PmError and PmDeviceID have been changed to take and return CInt rather than Int
+    - Haskell functions interfacing with C calls have had fromIntegral calls added as needed
+    - toPMError convenience function added, which replaced many calls to toEnum
+    - FFI declaration for Pm_CountDevices added, countDevices became a Haskell function
+    - PMError's toEnum function produces a more useful error message when the "impossible" happens
+
+    darcs-hash:20150921181604-63162-de113c7c4da4f42d274b8b6c0641563c8670f606
+
+commit cfae744f937cf4dfafd9e03bce9e0088a5b375f5
+Author: Mark Lentczner <mark.lentczner@gmail.com>
+Date:   Mon Sep 21 11:15:00 2015 -0700
+
+    Add strictness annotation when necessary
+
+    Ignore-this: 9e5792f9ad04c797fcd51b244d7485fa
+
+    darcs-hash:20150921181500-63162-dd522488d7f680cf536655d8cb1a878e489dcc98
+
+commit 4fb6f505b2f495bad6ddd1072ff41b51001d9b44
+Author: Paul Liu <paul@thev.net>
+Date:   Wed May 6 00:33:40 2015 -0700
+
+    Update cabal file, and bump version to 0.1.4
+
+    Ignore-this: 8b1d17f401ebd925a4bc6ff7778b453d
+
+    darcs-hash:20150506073340-da8e5-0cf190250915842e35fc5f3177e576d84fb82026
+
+commit a164e464065c84f3f4e958c53271f930c097f2d3
+Author: Paul Liu <paul@thev.net>
+Date:   Wed May 6 00:33:10 2015 -0700
+
+    Use withCAString for writeSysEx
+
+    Ignore-this: 9499c201b5fb289cda27c090fdbf1541
+
+    darcs-hash:20150506073310-da8e5-ecd2cf32c5f121cc95b97c1e9a495d189b0391cc
+
+commit c3ad563bbce9fbc25c8470865ded7b070d0d030e
+Author: Paul Liu <paul@thev.net>
+Date:   Wed Sep 16 11:06:11 2009 -0700
+
+    remove conflicts in cabal file
+
+    Ignore-this: 3ef1f4b655182e4cc5eb861e8f2427f1
+
+    darcs-hash:20090916180611-da8e5-47cff7e32f38c7d54155784dbf2ddee6f1053faf
+
+commit 6b0963d50576c0572155e421a4e6d02c8c649d8c
+Author: Paul Liu <paul@thev.net>
+Date:   Wed Sep 16 11:01:59 2009 -0700
+
+    fix compilation problem on OS X
+
+    Ignore-this: a87d64d1c1a59bd161edecbde23932e3
+
+    darcs-hash:20090916180159-da8e5-62407ea637a40e789f7e316a6fe181f56bc8fa1f
+
+commit 13c1d569f8566968bd0a214903d11c08a1101a2a
+Author: Paul Liu <paul@thev.net>
+Date:   Thu Jul 30 14:32:59 2009 -0700
+
+    make cabal work for ghc 6.10.* on OS X
+
+    darcs-hash:20090730213259-da8e5-f5a2558120fba824bb05440a8d7e3a2985fab2ed
+
+commit 8b7e2ea3c5ef6cb2b436e136964c2ee5814ffc02
+Author: Paul Liu <paul@thev.net>
+Date:   Thu Sep 4 18:59:02 2008 -0700
+
+    PortMidi-0.1 initial release
+
+    darcs-hash:20080905015902-da8e5-902a16abf5d28adda47ab45f6c0927a1042caf09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ The format of this changelog is based on
     namely 'NoError' and 'GotData', were moved to a new type 'PMSuccess'.
 
 ### Added
-- The `poll` function was added (it binds to `Pm_Poll`) : it allows to know,
-  without reading the events, if some events are present.
+- The `poll` function was added, it binds to `Pm_Poll`.
 
 
 ## 0.1.6.1

--- a/PortMidi.cabal
+++ b/PortMidi.cabal
@@ -1,5 +1,5 @@
 name:          PortMidi
-version:       0.1.6.1
+version:       0.2.0.0
 Cabal-Version: >= 1.6
 build-type:    Simple
 license:       BSD3

--- a/PortMidi.cabal
+++ b/PortMidi.cabal
@@ -5,6 +5,7 @@ build-type:    Simple
 license:       BSD3
 license-file:  LICENSE
 maintainer:    Paul H. Liu <paul@thev.net>
+             , Olivier Sohn <olivier.sohn@gmail.com>
 homepage:      http://github.com/ninegua/PortMidi
 category:      Sound
 stability:     experimental
@@ -12,7 +13,7 @@ synopsis:      A binding for PortMedia/PortMidi
 description:   A Haskell binding for PortMedia/PortMidi
 extra-source-files:
         README.txt
-        CHANGELOG.txt
+        CHANGELOG.md
         portmidi/pm_common/portmidi.h
         portmidi/pm_common/pmutil.h
         portmidi/pm_common/pminternal.h
@@ -29,8 +30,8 @@ Library
   extensions:      CPP, ForeignFunctionInterface
   if os(linux) || os(freebsd)
     include-dirs: portmidi/pm_common portmidi/pm_linux portmidi/porttime
-    cc-options: -DPMALSA 
-    c-sources:    
+    cc-options: -DPMALSA
+    c-sources:
           portmidi/pm_common/pmutil.c
           portmidi/pm_common/portmidi.c
           portmidi/pm_linux/pmlinux.c
@@ -42,7 +43,7 @@ Library
     if os(darwin)
      include-dirs: portmidi/pm_common portmidi/pm_mac portmidi/porttime
      cc-options:   -msse2
-     c-sources:  
+     c-sources:
           portmidi/pm_common/pmutil.c
           portmidi/pm_common/portmidi.c
           portmidi/pm_mac/pmmac.c
@@ -53,15 +54,14 @@ Library
     else
       if os(mingw32)
         include-dirs: portmidi/pm_common portmidi/pm_win portmidi/porttime
-        c-sources:  
+        c-sources:
           portmidi/pm_common/pmutil.c
           portmidi/pm_common/portmidi.c
           portmidi/pm_win/pmwin.c
           portmidi/pm_win/pmwinmm.c
           portmidi/porttime/porttime.c
           portmidi/porttime/ptwinmm.c
-        extra-libraries: winmm 
+        extra-libraries: winmm
 source-repository head
   type:         git
   location:     https://github.com/ninegua/PortMidi
-

--- a/Sound/PortMidi.hs
+++ b/Sound/PortMidi.hs
@@ -3,14 +3,15 @@
 -}
 {-# LANGUAGE EmptyDataDecls #-}
 
-module Sound.PortMidi ( 
+module Sound.PortMidi (
   -- * Data Types
     PMError(..)
+  , PMSuccess(..)
   , PMStream
   , DeviceInfo(..)
   , DeviceID
   , PMMsg(..)
-  , PMEvent(..) 
+  , PMEvent(..)
   -- * Constants
   , filterActive
   , filterSysex
@@ -49,10 +50,11 @@ module Sound.PortMidi (
   , setChannelMask
   , abort
   , close
+  , poll
   , readEvents
   , writeEvents
   , writeShort
-  , writeSysEx 
+  , writeSysEx
   -- * Time function
   , time
   --
@@ -63,18 +65,25 @@ module Sound.PortMidi (
 
 import Foreign
 import Foreign.C
-import Foreign.Marshal
-import Foreign.Storable
-import Data.IORef
-import Data.Bits
-import System.IO.Unsafe
 
 import Sound.PortMidi.DeviceInfo
 
-data PMError
-  = NoError
+data PMSuccess
+  = NoError'NoData
+  -- ^ Means no data when returned by 'poll', else means no error.
   | GotData
-  | HostError
+  -- ^ Returned by 'poll' only, means that data is available.
+  deriving (Eq, Show)
+
+instance Enum PMSuccess where
+  fromEnum NoError'NoData = 0
+  fromEnum GotData = 1
+  toEnum 0 = NoError'NoData
+  toEnum 1 = GotData
+  toEnum x = error $ "PortMidi: PMSuccess toEnum out of bound " ++ show x
+
+data PMError
+  = HostError
   | InvalidDeviceId
   | InsufficientMemory
   | BufferTooSmall
@@ -86,8 +95,6 @@ data PMError
   deriving (Eq, Show)
 
 instance Enum PMError where
-  fromEnum NoError = 0
-  fromEnum GotData = 1
   fromEnum HostError = -10000
   fromEnum InvalidDeviceId = -9999
   fromEnum InsufficientMemory = -9998
@@ -97,8 +104,6 @@ instance Enum PMError where
   fromEnum BadData = -9994
   fromEnum InternalError = -9993
   fromEnum BufferMaxSize = -9992
-  toEnum 0 = NoError
-  toEnum 1 = GotData
   toEnum (-10000) = HostError
   toEnum (-9999) = InvalidDeviceId
   toEnum (-9998) = InsufficientMemory
@@ -108,22 +113,29 @@ instance Enum PMError where
   toEnum (-9994) = BadData
   toEnum (-9993) = InternalError
   toEnum (-9992) = BufferMaxSize
-  toEnum x = error $ "PortMidi: toEnum out of bound " ++ show x
+  toEnum x = error $ "PortMidi: PMError toEnum out of bound " ++ show x
 
-toPMError :: CInt -> PMError
-toPMError = toEnum . fromIntegral
+toPMError :: CInt -> Either PMError PMSuccess
+toPMError n
+  | isSuccess = Right $ toEnum $ fromIntegral n
+  | otherwise = Left $ toEnum $ fromIntegral n
+  where
+    isSuccess = n == 0 || n == 1
 
 data PortMidiStream
 type PMStreamPtr = Ptr PortMidiStream
 type PMStream = ForeignPtr PortMidiStream
 type DeviceID = Int
 
+(.<.) :: CLong -> Int -> CLong
 (.<.) = shiftL
+
+(.>.) :: CLong -> Int -> CLong
 (.>.) = shiftR
 
 filterActive, filterSysex, filterClock, filterPlay, filterTick, filterFD, filterUndefined, filterReset, filterRealtime, filterNote, filterChannelAftertouch, filterPolyAftertouch, filterAftertouch, filterProgram, filterControl, filterPitchBend, filterMTC, filterSongPosition, filterSongSelect, filterTune, filterSystemCommon :: CLong
 
-filterActive = 1 .<. 0x0e 
+filterActive = 1 .<. 0x0e
 filterSysex = 1 .<. 0x00
 filterClock = 1 .<. 0x08
 filterPlay = (1 .<. 0x0A) .|. (1 .<. 0x0C) .|. (1 .<. 0x0B)
@@ -131,7 +143,7 @@ filterTick = 1 .<. 0x09
 filterFD = 1 .<. 0x0D
 filterUndefined = filterFD
 filterReset = 1 .<. 0x0F
-filterRealtime = filterActive .|. filterSysex .|. filterClock .|. filterPlay .|. filterUndefined .|. filterReset .|. filterTick 
+filterRealtime = filterActive .|. filterSysex .|. filterClock .|. filterPlay .|. filterUndefined .|. filterReset .|. filterTick
 filterNote = (1 .<. 0x19) .|. (1 .<. 0x18)
 filterChannelAftertouch = 1 .<. 0x1D
 filterPolyAftertouch = 1 .<. 0x1A
@@ -145,11 +157,11 @@ filterSongSelect = 1 .<. 0x03
 filterTune = 1 .<. 0x06
 filterSystemCommon = filterMTC .|. filterSongPosition .|. filterSongSelect .|. filterTune
 
-data PMMsg 
+data PMMsg
   =  PMMsg
-  { status :: !CLong
-  , data1  :: !CLong
-  , data2  :: !CLong
+  { status :: {-# UNPACK #-} !CLong
+  , data1  :: {-# UNPACK #-} !CLong
+  , data2  :: {-# UNPACK #-} !CLong
   } deriving (Eq, Show)
 
 encodeMsg :: PMMsg -> CLong
@@ -159,10 +171,10 @@ decodeMsg i = PMMsg (i .&. 0xFF) ((i .>. 8) .&. 0xFF) ((i .>. 16) .&. 0xFF)
 
 type Timestamp = CULong
 
-data PMEvent 
-  =  PMEvent 
-  { message   :: !CLong
-  , timestamp :: !Timestamp
+data PMEvent
+  =  PMEvent
+  { message   :: {-# UNPACK #-} !CLong
+  , timestamp :: {-# UNPACK #-} !Timestamp
   } deriving (Eq, Show)
 
 instance Storable PMEvent where
@@ -178,11 +190,11 @@ instance Storable PMEvent where
 
 
 foreign import ccall "portmidi.h Pm_Initialize" pm_Initialize :: IO CInt
-initialize :: IO PMError
+initialize :: IO (Either PMError PMSuccess)
 initialize = pm_Initialize >>= return . toPMError
 
 foreign import ccall "portmidi.h Pm_Terminate" pm_Terminate :: IO CInt
-terminate :: IO PMError
+terminate :: IO (Either PMError PMSuccess)
 terminate = pm_Terminate >>= return . toPMError
 
 foreign import ccall "portmidi.h Pm_HasHostError" pm_HasHostError :: PMStreamPtr -> IO CInt
@@ -213,72 +225,68 @@ getDeviceInfo :: DeviceID -> IO DeviceInfo
 getDeviceInfo deviceID = pm_GetDeviceInfo (fromIntegral deviceID) >>= peekDeviceInfo
 
 foreign import ccall "portmidi.h Pm_OpenInput" pm_OpenInput :: Ptr PMStreamPtr -> CInt -> Ptr () -> CLong -> Ptr () -> Ptr () -> IO CInt
-openInput :: DeviceID -> IO (Either PMStream PMError)
-openInput inputDevice = 
-  with nullPtr (\ptr -> do
-    e <- pm_OpenInput ptr (fromIntegral inputDevice) nullPtr 0 nullPtr nullPtr
-    if e == 0 
-      then do
+openInput :: DeviceID -> IO (Either PMError PMStream)
+openInput inputDevice =
+  with nullPtr (\ptr ->
+    toPMError <$> pm_OpenInput ptr (fromIntegral inputDevice) nullPtr 0 nullPtr nullPtr >>= either
+      (return . Left)
+      (\_ -> do
         stream <- peek ptr
-        ptr' <- newForeignPtr_ stream
-        return $ Left ptr'
-      else return (Right (toPMError e)))
-      
+        Right <$> newForeignPtr_ stream))
+
 foreign import ccall "portmidi.h Pm_OpenOutput" pm_OpenOutput :: Ptr PMStreamPtr -> CInt -> Ptr () -> CLong -> Ptr () -> Ptr () -> CLong -> IO CInt
-openOutput :: DeviceID -> Int -> IO (Either PMStream PMError)
+openOutput :: DeviceID -> Int -> IO (Either PMError PMStream)
 openOutput outputDevice latency =
   with nullPtr (\ptr -> do
-    e <- pm_OpenOutput ptr (fromIntegral outputDevice) nullPtr 0 nullPtr nullPtr (fromIntegral latency)
-    if e == 0 
-      then do
+    toPMError <$> pm_OpenOutput ptr (fromIntegral outputDevice) nullPtr 0 nullPtr nullPtr (fromIntegral latency) >>= either
+      (return . Left)
+      (\_ -> do
         stream <- peek ptr
-        ptr' <- newForeignPtr_ stream
-        return $ Left ptr'
-      else return (Right (toPMError e)))
+        Right <$> newForeignPtr_ stream))
 
 foreign import ccall "portmidi.h Pm_SetFilter" pm_SetFilter :: PMStreamPtr -> CLong -> IO CInt
-setFilter :: PMStream -> CLong -> IO PMError
-setFilter stream filter = withForeignPtr stream (\s -> pm_SetFilter s filter >>= return . toPMError)
+setFilter :: PMStream -> CLong -> IO (Either PMError PMSuccess)
+setFilter stream theFilter = withForeignPtr stream (fmap toPMError . flip pm_SetFilter theFilter)
 
 channel :: Int -> CLong
 channel i = 1 .<. i
 
 foreign import ccall "portmidi.h Pm_SetChannelMask" pm_SetChannelMask :: PMStreamPtr -> CLong -> IO CInt
-setChannelMask :: PMStream -> CLong -> IO PMError
-setChannelMask stream mask = withForeignPtr stream (\s -> pm_SetChannelMask s mask >>= return . toPMError)
+setChannelMask :: PMStream -> CLong -> IO (Either PMError PMSuccess)
+setChannelMask stream mask = withForeignPtr stream (fmap toPMError . flip pm_SetChannelMask mask)
 
 foreign import ccall "portmidi.h Pm_Abort" pm_Abort :: PMStreamPtr -> IO CInt
-abort :: PMStream -> IO PMError
-abort = flip withForeignPtr (\s -> pm_Abort s >>= return . toPMError)
+abort :: PMStream -> IO (Either PMError PMSuccess)
+abort = flip withForeignPtr (fmap toPMError . pm_Abort)
 
 foreign import ccall "portmidi.h Pm_Close" pm_Close :: PMStreamPtr -> IO CInt
-close :: PMStream -> IO PMError
-close = flip withForeignPtr (\s -> pm_Close s >>= return . toPMError)
+close :: PMStream -> IO (Either PMError PMSuccess)
+close = flip withForeignPtr (fmap toPMError . pm_Close)
+
+foreign import ccall "portmidi.h Pm_Poll" pm_Poll :: PMStreamPtr -> IO CInt
+poll :: PMStream -> IO (Either PMError PMSuccess)
+poll = flip withForeignPtr (fmap toPMError . pm_Poll)
 
 foreign import ccall "portmidi.h Pm_Read" pm_Read :: PMStreamPtr -> Ptr PMEvent -> CLong -> IO CInt
-readEvents :: PMStream -> IO (Either [PMEvent] PMError)
-readEvents = flip withForeignPtr (\s -> allocaArray (fromIntegral defaultBufferSize) (\arr -> do
-  r <- pm_Read s arr defaultBufferSize
-  if r > 0
-    then peekArray (fromIntegral r) arr >>= return . Left
-    else return $ Right (toPMError r)))
-  where
-    defaultBufferSize = 256
+readEvents :: PMStream -> IO [PMEvent]
+readEvents = flip withForeignPtr $ \s -> allocaArray (fromIntegral defaultBufferSize) $ \arr ->
+  pm_Read s arr defaultBufferSize >>= flip peekArray arr . fromIntegral
+ where
+  defaultBufferSize = 256
 
 foreign import ccall "portmidi.h Pm_Write" pm_Write :: PMStreamPtr -> Ptr PMEvent -> CLong -> IO CInt
-writeEvents :: PMStream -> [PMEvent] -> IO PMError
-writeEvents stream events = withForeignPtr stream (\s -> 
-  withArrayLen events (\len arr -> pm_Write s arr (fromIntegral len) >>= return . toPMError))
+writeEvents :: PMStream -> [PMEvent] -> IO (Either PMError PMSuccess)
+writeEvents stream events = withForeignPtr stream (\s ->
+  withArrayLen events (\len arr -> toPMError <$> pm_Write s arr (fromIntegral len)))
 
 foreign import ccall "portmidi.h Pm_WriteShort" pm_WriteShort :: PMStreamPtr -> CULong -> CLong -> IO CInt
-writeShort :: PMStream -> PMEvent -> IO PMError
-writeShort stream (PMEvent msg time) = withForeignPtr stream (\s ->
-  pm_WriteShort s time msg >>= return . toPMError)
+writeShort :: PMStream -> PMEvent -> IO (Either PMError PMSuccess)
+writeShort stream (PMEvent msg t) = withForeignPtr stream (\s ->
+  toPMError <$> pm_WriteShort s t msg)
 
 foreign import ccall "portmidi.h Pm_WriteSysEx" pm_WriteSysEx :: PMStreamPtr -> CULong -> CString -> IO CInt
-writeSysEx :: PMStream -> Timestamp -> String -> IO PMError
-writeSysEx stream time str = withForeignPtr stream (\st ->
-  withCAString str (\s -> pm_WriteSysEx st time s >>= return . toPMError))
+writeSysEx :: PMStream -> Timestamp -> String -> IO (Either PMError PMSuccess)
+writeSysEx stream t str = withForeignPtr stream (\st ->
+  withCAString str (\s -> toPMError <$> pm_WriteSysEx st t s))
 
-foreign import ccall "porttime.h Pt_Time" time :: IO Timestamp      
-
+foreign import ccall "porttime.h Pt_Time" time :: IO Timestamp

--- a/Sound/PortMidi/DeviceInfo.hsc
+++ b/Sound/PortMidi/DeviceInfo.hsc
@@ -19,6 +19,7 @@ data DeviceInfo
   , opened    :: Bool
   } deriving (Eq, Show)
 
+peekDeviceInfo :: Ptr a -> IO DeviceInfo
 peekDeviceInfo ptr = do
   s <- #{peek PmDeviceInfo, interf} ptr >>= peekCString
   u <- #{peek PmDeviceInfo, name} ptr >>= peekCString

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,11 @@
+
+resolver: lts-11.9
+
+packages:
+- '.'
+
+extra-deps: []
+
+flags: {}
+
+extra-package-dbs: []


### PR DESCRIPTION
Closes #7 

In the changelog, I proposed the next version to be `0.2.0.0` : the second digit is incremented because this is a breaking change, as the signature of API functions changes.

What I did is conform to the conventional way of returning errors using `Either` : real errors are in the `Left` constructor, successes in the `Right` one.  Since `readEvents` never returns a real error, it just returns the list of messages now, which can be empty.

And the 2 "non error" constructors of `PMError` are moved to a new type `PMSuccess`.

(I also included the binding to `PM_Poll` in this PR but can move it to a separate one if needed)

Also along the way I simplified a bit some parts of the code, and fixed the warnings I saw while compiling with `stack build --pedantic` (mainly missing top level declarations, and variable name shadowings)

I also used `UNPACK` to have more optimal memory usage.