### PR TITLE
introduces readEventsToBuffer (and fix regression on readEvents introduced by my previous commit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ The format of this changelog is based on
     namely 'NoError' and 'GotData', were moved to a new type 'PMSuccess'.
 
 ### Added
-- The `poll` function was added, it binds to `Pm_Poll`.
+- The `poll` function which binds to `Pm_Poll`.
+- The `readEventsToBuffer` function, to read events in a user-supplied buffer.
+    This function returns a `PMEventCount`, representing the count of `PMEvent`s
+    that was read.
+- The `PMSuccess` type representing non-errors, with its the associated
+    functions `getText` and `getSuccessText`.
 
 
 ## 0.1.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format of this changelog is based on
 - The `readEventsToBuffer` function, to read events in a user-supplied buffer.
     This function returns a `PMEventCount`, representing the count of `PMEvent`s
     that was read.
-- The `PMSuccess` type representing non-errors, with its the associated
+- The `PMSuccess` type representing non-errors, with its associated
     functions `getText` and `getSuccessText`.
 
 


### PR DESCRIPTION
While working on this, I found that in the previous PR, I have introduced a regression in `readEvents`, which would no longer return any error: it's now fixed.

`readEvents` depends on the new function `readEventsToBuffer`, to avoid code duplication.

I also added some functions that were missing in the previous PR : `getSuccessText` and `getText`

I renamed `toPMError` to `eitherErrorOrSuccess` because I also introduced a `eitherErrorOrCount ` function and I wanted the naming to be consistent (actually this name should have been changed in the previous PR because now PMError is split in PMError + PMSuccess ...)

This closes #6