### PR TITLE
Fix compilation errors on 64-bit linux

### DIFF
--- a/portmidi/pm_common/pminternal.h
+++ b/portmidi/pm_common/pminternal.h
@@ -155,7 +155,7 @@ PmError pm_fail_timestamp_fn(PmInternal *midi, PmTimestamp timestamp);
 PmError pm_success_fn(PmInternal *midi);
 PmError pm_add_device(char *interf, char *name, int input, void *descriptor,
                       pm_fns_type dictionary);
-unsigned int pm_read_bytes(PmInternal *midi, unsigned char *data, int len,
+unsigned int pm_read_bytes(PmInternal *midi, const unsigned char *data, int len,
                            PmTimestamp timestamp);
 void pm_read_short(PmInternal *midi, PmEvent *event);
 

--- a/portmidi/pm_common/portmidi.c
+++ b/portmidi/pm_common/portmidi.c
@@ -999,7 +999,7 @@ void pm_read_short(PmInternal *midi, PmEvent *event)
 /*
  * returns how many bytes processed
  */
-unsigned int pm_read_bytes(PmInternal *midi, unsigned char *data, 
+unsigned int pm_read_bytes(PmInternal *midi, const unsigned char *data, 
                     int len, PmTimestamp timestamp)
 {
     unsigned int i = 0; /* index into data */

--- a/portmidi/pm_linux/pmlinuxalsa.c
+++ b/portmidi/pm_linux/pmlinuxalsa.c
@@ -32,9 +32,9 @@
 #endif
 
 /* to store client/port in the device descriptor */
-#define MAKE_DESCRIPTOR(client, port) ((void*)(((client) << 8) | (port)))
-#define GET_DESCRIPTOR_CLIENT(info) ((((int)(info)) >> 8) & 0xff)
-#define GET_DESCRIPTOR_PORT(info) (((int)(info)) & 0xff)
+#define MAKE_DESCRIPTOR(client, port) ((void*)(size_t)(((client) << 8) | (port)))
+#define GET_DESCRIPTOR_CLIENT(info) ((((size_t)(info)) >> 8) & 0xff)
+#define GET_DESCRIPTOR_PORT(info) (((size_t)(info)) & 0xff)
 
 #define BYTE unsigned char
 #define UINT unsigned long
@@ -209,7 +209,7 @@ static PmError alsa_write_byte(PmInternal *midi, unsigned char byte,
             if (when == 0) when = now;
             when = (when - now) + midi->latency;
             if (when < 0) when = 0;
-            VERBOSE printf("timestamp %d now %d latency %d, ", 
+            VERBOSE printf("timestamp %d now %d latency %ld, ", 
                            (int) timestamp, (int) now, midi->latency);
             VERBOSE printf("scheduling event after %d\n", when);
             /* message is sent in relative ticks, where 1 tick = 1 ms */
@@ -438,7 +438,7 @@ static PmError alsa_write(PmInternal *midi, PmEvent *buffer, long length)
 static PmError alsa_write_flush(PmInternal *midi, PmTimestamp timestamp)
 {
     alsa_descriptor_type desc = (alsa_descriptor_type) midi->descriptor;
-    VERBOSE printf("snd_seq_drain_output: 0x%x\n", (unsigned int) seq);
+    VERBOSE printf("snd_seq_drain_output: 0x%lx\n", (size_t) seq);
     desc->error = snd_seq_drain_output(seq);
     if (desc->error < 0) return pmHostError;
 

--- a/portmidi/pm_linux/pmlinuxalsa.c
+++ b/portmidi/pm_linux/pmlinuxalsa.c
@@ -438,7 +438,7 @@ static PmError alsa_write(PmInternal *midi, PmEvent *buffer, long length)
 static PmError alsa_write_flush(PmInternal *midi, PmTimestamp timestamp)
 {
     alsa_descriptor_type desc = (alsa_descriptor_type) midi->descriptor;
-    VERBOSE printf("snd_seq_drain_output: 0x%lx\n", (size_t) seq);
+    VERBOSE printf("snd_seq_drain_output: 0x%p\n", seq);
     desc->error = snd_seq_drain_output(seq);
     if (desc->error < 0) return pmHostError;
 


### PR DESCRIPTION
Somehow compiling under 64-bit NixOS the C compiler would treat warnings as errors, which prevents this package from compiling. So I fixed a few things to get through, hopefully won't break 32-bit build.